### PR TITLE
Added AU and HK flag

### DIFF
--- a/.catalog/README.md
+++ b/.catalog/README.md
@@ -14,6 +14,8 @@
 🇪🇸
 🇪🇪
 🇨🇭
+🇦🇺
+🇭🇰
 
 (If it works for yours, submit a PR to add your country flag)
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@
 🇪🇸
 🇪🇪
 🇨🇭
+🇦🇺
+🇭🇰
 
 
 *If it works for yours, submit a PR to add your country flag!*


### PR DESCRIPTION
Tested with Hong Kong and Australia passport. 

Both was able to get the DG1 and DG2 info. 

For Australia passport, it has 2 uppercase letter. I could not enter uppercase letter in the flipper zero. I had to use the phone app to edit `mrz_info.txt` directly with the uppercase letters and then it works.

I noticed in [passy_scene_passport_number_input.c](https://github.com/bettse/passy/blob/main/scenes/passy_scene_passport_number_input.c#L48), there is already a toupper function, but not sure why its not saving the uppercase version. 