### PR TITLE
Fix some buffer size issues, preventing crashes

### DIFF
--- a/passy.c
+++ b/passy.c
@@ -27,14 +27,14 @@ bool passy_load_mrz_info(Passy* passy) {
         // doe
 
         if(!flipper_format_read_string(file, "Passport Number", temp_str)) break;
-        strncpy(
+        strlcpy(
             passy->passport_number,
             furi_string_get_cstr(temp_str),
             PASSY_PASSPORT_NUMBER_MAX_LENGTH);
         if(!flipper_format_read_string(file, "Date of Birth", temp_str)) break;
-        strncpy(passy->date_of_birth, furi_string_get_cstr(temp_str), PASSY_DOB_MAX_LENGTH);
+        strlcpy(passy->date_of_birth, furi_string_get_cstr(temp_str), PASSY_DOB_MAX_LENGTH);
         if(!flipper_format_read_string(file, "Date of Expiry", temp_str)) break;
-        strncpy(passy->date_of_expiry, furi_string_get_cstr(temp_str), PASSY_DOE_MAX_LENGTH);
+        strlcpy(passy->date_of_expiry, furi_string_get_cstr(temp_str), PASSY_DOE_MAX_LENGTH);
 
         parsed = true;
     } while(false);

--- a/passy_i.h
+++ b/passy_i.h
@@ -33,11 +33,11 @@
 #include "passy_common.h"
 #include "scenes/passy_scene.h"
 
-#define PASSY_TEXT_STORE_SIZE            128
-#define PASSY_FILE_NAME_MAX_LENGTH       32
-#define PASSY_PASSPORT_NUMBER_MAX_LENGTH 32
-#define PASSY_DOB_MAX_LENGTH             8
-#define PASSY_DOE_MAX_LENGTH             8
+#define PASSY_TEXT_STORE_SIZE            128 // Including NULL-terminator
+#define PASSY_FILE_NAME_MAX_LENGTH       32 // Including NULL-terminator
+#define PASSY_PASSPORT_NUMBER_MAX_LENGTH 20 // Including NULL-terminator
+#define PASSY_DOB_MAX_LENGTH             8 // YYMMDD + check digit + NULL-terminator
+#define PASSY_DOE_MAX_LENGTH             8 // YYMMDD + check digit + NULL-terminator
 
 #define PASSY_DG1_MAX_LENGTH 256
 
@@ -64,7 +64,7 @@ struct Passy {
     SceneManager* scene_manager;
     Storage* storage;
 
-    char text_store[PASSY_TEXT_STORE_SIZE + 1];
+    char text_store[PASSY_TEXT_STORE_SIZE];
     FuriString* text_box_store;
 
     // Common Views
@@ -84,11 +84,11 @@ struct Passy {
     NfcDevice* nfc_device;
 
     FuriString* load_path;
-    char file_name[PASSY_FILE_NAME_MAX_LENGTH + 1];
+    char file_name[PASSY_FILE_NAME_MAX_LENGTH];
 
-    char passport_number[PASSY_PASSPORT_NUMBER_MAX_LENGTH + 1];
-    char date_of_birth[PASSY_DOB_MAX_LENGTH + 1];
-    char date_of_expiry[PASSY_DOE_MAX_LENGTH + 1];
+    char passport_number[PASSY_PASSPORT_NUMBER_MAX_LENGTH];
+    char date_of_birth[PASSY_DOB_MAX_LENGTH];
+    char date_of_expiry[PASSY_DOE_MAX_LENGTH];
 
     BitBuffer* DG1;
     BitBuffer* COM;

--- a/passy_reader.c
+++ b/passy_reader.c
@@ -56,21 +56,23 @@ PassyReader* passy_reader_alloc(Passy* passy) {
     passy_reader->tx_buffer = bit_buffer_alloc(PASSY_READER_MAX_BUFFER_SIZE);
     passy_reader->rx_buffer = bit_buffer_alloc(PASSY_READER_MAX_BUFFER_SIZE);
 
-    char passport_number[11];
+    char passport_number[PASSY_PASSPORT_NUMBER_MAX_LENGTH];
     memset(passport_number, 0, sizeof(passport_number));
-    memcpy(passport_number, passy->passport_number, strlen(passy->passport_number));
+    strlcpy(passport_number, passy->passport_number, PASSY_PASSPORT_NUMBER_MAX_LENGTH - 1);
+    // strlcpy leaves at least 1 byte for check digit
+    // the next byte is already '\0' because of the memset
     passport_number[strlen(passy->passport_number)] = passy_checksum(passy->passport_number);
     FURI_LOG_I(TAG, "Passport number: %s", passport_number);
 
-    char date_of_birth[8];
+    char date_of_birth[PASSY_DOB_MAX_LENGTH];
     memset(date_of_birth, 0, sizeof(date_of_birth));
-    memcpy(date_of_birth, passy->date_of_birth, strlen(passy->date_of_birth));
+    strlcpy(date_of_birth, passy->date_of_birth, PASSY_DOB_MAX_LENGTH - 1);
     date_of_birth[strlen(passy->date_of_birth)] = passy_checksum(passy->date_of_birth);
     FURI_LOG_I(TAG, "Date of birth: %s", date_of_birth);
 
-    char date_of_expiry[8];
+    char date_of_expiry[PASSY_DOE_MAX_LENGTH];
     memset(date_of_expiry, 0, sizeof(date_of_expiry));
-    memcpy(date_of_expiry, passy->date_of_expiry, strlen(passy->date_of_expiry));
+    strlcpy(date_of_expiry, passy->date_of_expiry, PASSY_DOE_MAX_LENGTH - 1);
     date_of_expiry[strlen(passy->date_of_expiry)] = passy_checksum(passy->date_of_expiry);
     FURI_LOG_I(TAG, "Date of expiry: %s", date_of_expiry);
 

--- a/scenes/passy_scene_dob_input.c
+++ b/scenes/passy_scene_dob_input.c
@@ -38,7 +38,7 @@ bool passy_scene_dob_input_on_event(void* context, SceneManagerEvent event) {
 
     if(event.type == SceneManagerEventTypeCustom) {
         if(event.event == PassyCustomEventTextInputDone) {
-            strlcpy(passy->date_of_birth, passy->text_store, strlen(passy->text_store) + 1);
+            strlcpy(passy->date_of_birth, passy->text_store, sizeof(passy->date_of_birth));
             scene_manager_next_scene(passy->scene_manager, PassySceneDoEInput);
             consumed = true;
         }

--- a/scenes/passy_scene_doe_input.c
+++ b/scenes/passy_scene_doe_input.c
@@ -37,7 +37,7 @@ bool passy_scene_doe_input_on_event(void* context, SceneManagerEvent event) {
 
     if(event.type == SceneManagerEventTypeCustom) {
         if(event.event == PassyCustomEventTextInputDone) {
-            strlcpy(passy->date_of_expiry, passy->text_store, strlen(passy->text_store) + 1);
+            strlcpy(passy->date_of_expiry, passy->text_store, sizeof(passy->date_of_expiry));
             passy_save_mrz_info(passy);
             scene_manager_next_scene(passy->scene_manager, PassySceneMainMenu);
             consumed = true;

--- a/scenes/passy_scene_passport_number_input.c
+++ b/scenes/passy_scene_passport_number_input.c
@@ -48,7 +48,7 @@ bool passy_scene_passport_number_input_on_event(void* context, SceneManagerEvent
                 passy->text_store[i] = toupper(passy->text_store[i]);
             }
 
-            strlcpy(passy->passport_number, passy->text_store, strlen(passy->text_store) + 1);
+            strlcpy(passy->passport_number, passy->text_store, sizeof(passy->passport_number));
             scene_manager_next_scene(passy->scene_manager, PassySceneDoBInput);
             consumed = true;
         }


### PR DESCRIPTION
This PR fixes some issues with buffers, reducing the amount of crashes on extreme inputs.

1. Consistently define buffer sizes to include room for check digit and NULL-terminator
2. In regards to 1. also remove the additional `+1` from buffer allocations
3. Use safer `strlcpy` to copy NULL-terminated strings
4. Use destination size in `strlcpy` to prevent buffer overflows

The size of `char passport_number[]` in `passy_reader.c` was already limited to `11`. `20` is closer to the previously, inconsistently used `11` and still leaves some extra room aboce the usual `9` characters of a document number.

If, due to an error or extensive input `passy->passport_number` contains more characters than fit in `passport_number` locally, using `strlen` on the source creates a buffer overflow. This is mitigated by using the destination buffer size.
