### PR TITLE
Use proper buffer for progress update

### DIFF
--- a/scenes/passy_scene_read.c
+++ b/scenes/passy_scene_read.c
@@ -96,14 +96,13 @@ bool passy_scene_read_on_event(void* context, SceneManagerEvent event) {
                 popup_set_header(popup, "Reading", 68, 30, AlignLeft, AlignTop);
             } else {
                 // Update the header with the current bytes read
-                char header[32];
                 snprintf(
-                    header,
-                    sizeof(header),
+                    passy->text_store,
+                    PASSY_TEXT_STORE_SIZE,
                     "Reading\n%d/%dk",
                     passy->offset,
                     (passy->bytes_total / 1024));
-                popup_set_header(popup, header, 68, 30, AlignLeft, AlignTop);
+                popup_set_header(popup, passy->text_store, 68, 30, AlignLeft, AlignTop);
             }
         }
     } else if(event.type == SceneManagerEventTypeBack) {


### PR DESCRIPTION
The `char header[32]` is limited to the scope of the `else { ... }`. Anything written to it might be, and is, overwritten after this block. Passing this as an argument to `popup_set_header` is therefore unsafe.

With this PR the text_store in `struct Passy` is used, which remains available and solves the flickering display of progress.

Unlike [specified earlier](https://github.com/bettse/passy/pull/37/files/f2597671b999cbf3a3012316d4ce3bacf1fd4a4a#diff-3f661db9bfbef1470f83752ad6089172f6f705243739236f782147c34dfc58d8) the delay is not the right fix and not necessary.