### PR TITLE
Use tx_buffer for all messages and dynamic wrapping of secure messaging 

### DIFF
--- a/passy_common.c
+++ b/passy_common.c
@@ -37,7 +37,7 @@ void passy_log_bitbuffer(char* tag, char* prefix, BitBuffer* buffer) {
     }
 }
 
-void passy_log_buffer(char* tag, char* prefix, uint8_t* buffer, size_t buffer_len) {
+void passy_log_buffer(char* tag, char* prefix, const uint8_t* buffer, size_t buffer_len) {
     char display[PASSY_WORKER_MAX_BUFFER_SIZE * 2 + 1];
 
     size_t limit = MIN((size_t)PASSY_WORKER_MAX_BUFFER_SIZE, buffer_len);

--- a/passy_common.h
+++ b/passy_common.h
@@ -25,7 +25,7 @@ typedef enum {
 } PassyReadType;
 
 void passy_log_bitbuffer(char* tag, char* prefix, BitBuffer* buffer);
-void passy_log_buffer(char* tag, char* prefix, uint8_t* buffer, size_t buffer_len);
+void passy_log_buffer(char* tag, char* prefix, const uint8_t* buffer, size_t buffer_len);
 void passy_mac(uint8_t* key, uint8_t* data, size_t data_length, uint8_t* mac, bool prepadded);
 char passy_checksum(char* str);
 int print_struct_callback(const void* buffer, size_t size, void* app_key);

--- a/passy_reader.c
+++ b/passy_reader.c
@@ -193,7 +193,7 @@ NfcCommand passy_reader_get_challenge(PassyReader* passy_reader) {
     return ret;
 }
 
-NfcCommand passy_reader_authenticate(PassyReader* passy_reader) {
+NfcCommand passy_reader_external_authenticate(PassyReader* passy_reader) {
     NfcCommand ret = NfcCommandContinue;
     BitBuffer* tx_buffer = passy_reader->tx_buffer;
 
@@ -489,7 +489,7 @@ NfcCommand passy_reader_state_machine(PassyReader* passy_reader) {
             view_dispatcher_send_custom_event(passy->view_dispatcher, PassyCustomEventReaderError);
             break;
         }
-        ret = passy_reader_authenticate(passy_reader);
+        ret = passy_reader_external_authenticate(passy_reader);
         if(ret != NfcCommandContinue) {
             view_dispatcher_send_custom_event(passy->view_dispatcher, PassyCustomEventReaderError);
             break;

--- a/passy_reader.c
+++ b/passy_reader.c
@@ -275,8 +275,9 @@ NfcCommand passy_reader_select_file(PassyReader* passy_reader, uint16_t file_id)
     select_0101[5] = (file_id >> 8) & 0xFF;
     select_0101[6] = file_id & 0xFF;
 
-    secure_messaging_wrap_apdu(
-        passy_reader->secure_messaging, select_0101, sizeof(select_0101), passy_reader->tx_buffer);
+    bit_buffer_append_bytes(passy_reader->tx_buffer, select_0101, sizeof(select_0101));
+
+    secure_messaging_wrap_apdu(passy_reader->secure_messaging, passy_reader->tx_buffer);
 
     ret = passy_reader_send(passy_reader);
     if(ret != NfcCommandContinue) {
@@ -303,8 +304,9 @@ NfcCommand passy_reader_read_binary(
     }
     uint8_t read_binary[] = {0x00, 0xB0, (offset >> 8) & 0xff, (offset >> 0) & 0xff, Le};
 
-    secure_messaging_wrap_apdu(
-        passy_reader->secure_messaging, read_binary, sizeof(read_binary), passy_reader->tx_buffer);
+    bit_buffer_append_bytes(passy_reader->tx_buffer, read_binary, sizeof(read_binary));
+
+    secure_messaging_wrap_apdu(passy_reader->secure_messaging, passy_reader->tx_buffer);
 
     ret = passy_reader_send(passy_reader);
     if(ret != NfcCommandContinue) {

--- a/passy_reader.c
+++ b/passy_reader.c
@@ -21,6 +21,7 @@ static const uint8_t jpeg2k_header[6] = {0x00, 0x00, 0x00, 0x0C, 0x6A, 0x50};
 static const uint8_t jpeg2k_cs_header[4] = {0xFF, 0x4F, 0xFF, 0x51};
 
 static bool print_logs = true;
+static bool use_secure_messaging = false;
 
 size_t asn1_length(uint8_t data[3]) {
     if(data[0] <= 0x7F) {
@@ -97,6 +98,15 @@ NfcCommand passy_reader_send(PassyReader* passy_reader) {
     Passy* passy = passy_reader->passy;
     BitBuffer* tx_buffer = passy_reader->tx_buffer;
     BitBuffer* rx_buffer = passy_reader->rx_buffer;
+
+    if(print_logs) {
+        passy_log_bitbuffer(TAG, "Send APDU", tx_buffer);
+    }
+
+    if(use_secure_messaging) {
+        secure_messaging_wrap_apdu(passy_reader->secure_messaging, passy_reader->tx_buffer);
+    }
+
     if(strcmp(passy->proto, "4a") == 0) {
         Iso14443_4aPoller* iso14443_4a_poller = passy_reader->iso14443_4a_poller;
         Iso14443_4aError error;
@@ -141,6 +151,10 @@ NfcCommand passy_reader_send(PassyReader* passy_reader) {
     if(memcmp(data + length - 2, SW_success, sizeof(SW_success)) != 0) {
         FURI_LOG_W(TAG, "Invalid SW %02x %02x", data[length - 2], data[length - 1]);
         return NfcCommandStop;
+    }
+
+    if(use_secure_messaging) {
+        secure_messaging_unwrap_rapdu(passy_reader->secure_messaging, passy_reader->rx_buffer);
     }
 
     return ret;
@@ -277,14 +291,11 @@ NfcCommand passy_reader_select_file(PassyReader* passy_reader, uint16_t file_id)
 
     bit_buffer_append_bytes(passy_reader->tx_buffer, select_0101, sizeof(select_0101));
 
-    secure_messaging_wrap_apdu(passy_reader->secure_messaging, passy_reader->tx_buffer);
-
     ret = passy_reader_send(passy_reader);
     if(ret != NfcCommandContinue) {
         return ret;
     }
 
-    secure_messaging_unwrap_rapdu(passy_reader->secure_messaging, passy_reader->rx_buffer);
     if(print_logs) {
         passy_log_bitbuffer(TAG, "NFC response (decrypted)", passy_reader->rx_buffer);
     }
@@ -306,14 +317,11 @@ NfcCommand passy_reader_read_binary(
 
     bit_buffer_append_bytes(passy_reader->tx_buffer, read_binary, sizeof(read_binary));
 
-    secure_messaging_wrap_apdu(passy_reader->secure_messaging, passy_reader->tx_buffer);
-
     ret = passy_reader_send(passy_reader);
     if(ret != NfcCommandContinue) {
         return ret;
     }
 
-    secure_messaging_unwrap_rapdu(passy_reader->secure_messaging, passy_reader->rx_buffer);
     if(print_logs) {
         passy_log_bitbuffer(TAG, "NFC response (decrypted)", passy_reader->rx_buffer);
     }
@@ -468,6 +476,8 @@ NfcCommand passy_reader_state_machine(PassyReader* passy_reader) {
     Passy* passy = passy_reader->passy;
     NfcCommand ret = NfcCommandContinue;
 
+    use_secure_messaging = false;
+
     do {
         ret = passy_reader_select_application(passy_reader);
         if(ret != NfcCommandContinue) {
@@ -486,6 +496,7 @@ NfcCommand passy_reader_state_machine(PassyReader* passy_reader) {
         }
         FURI_LOG_I(TAG, "Mututal authentication success");
         secure_messaging_calculate_session_keys(passy_reader->secure_messaging);
+        use_secure_messaging = true;
         view_dispatcher_send_custom_event(
             passy->view_dispatcher, PassyCustomEventReaderAuthenticated);
 

--- a/secure_messaging.h
+++ b/secure_messaging.h
@@ -38,10 +38,6 @@ void secure_messaging_free(SecureMessaging* secure_messaging);
 
 void secure_messaging_calculate_session_keys(SecureMessaging* secure_messaging);
 
-void secure_messaging_wrap_apdu(
-    SecureMessaging* secure_messaging,
-    uint8_t* message,
-    size_t message_len,
-    BitBuffer* tx_buffer);
+void secure_messaging_wrap_apdu(SecureMessaging* secure_messaging, BitBuffer* tx_buffer);
 
 void secure_messaging_unwrap_rapdu(SecureMessaging* secure_messaging, BitBuffer* rx_buffer);


### PR DESCRIPTION
Before this PR there were message-types that are preformatted without secure messaging (SM) and others that were preformatted with SM. This adds differences between formats and handling that are not transparent, it also made re-use of functions/message-types impossible.

This PR changes:
- All message functions write to `tx_buffer` directly
- If `use_secure_messaging` is `true`, in `passy_reader_send`
  - outgoing messages are encrypted by `secure_messaging_wrap_apdu`
  - incoming messages are decrypted by `secure_messaging_unwrap_rapdu`
- `use_secure_messaging` is set to `true` after successful mutual authentication
- `secure_messaging_wrap_apdu`
  - encrypts the data in `tx_buffer`
  - puts the header and encrypted data back in `tx_buffer`
  - just like `secure_messaging_unwrap_rapdu` does with `rx_buffer`
  - making the SM transparent to message type functions

Additionally - let me know if you prefer separate PRs for this;
- `passy_reader_authenticate` is renamed to `passy_reader_external_authenticate` in line with ICAO 9303 P.11 §4.3.4.2
- some buffers are defined `const` to solve compiler warnings, where applicable and in line with its use