### PR TITLE
Improve stability going back while reading

### DIFF
--- a/scenes/passy_scene_read.c
+++ b/scenes/passy_scene_read.c
@@ -119,14 +119,14 @@ bool passy_scene_read_on_event(void* context, SceneManagerEvent event) {
 void passy_scene_read_on_exit(void* context) {
     Passy* passy = context;
 
-    if(passy_reader) {
-        passy_reader_free(passy_reader);
-        passy_reader = NULL;
-    }
     if(passy->poller) {
         nfc_poller_stop(passy->poller);
         nfc_poller_free(passy->poller);
         passy->poller = NULL;
+    }
+    if(passy_reader) {
+        passy_reader_free(passy_reader);
+        passy_reader = NULL;
     }
     if(passy->scanner) {
         nfc_scanner_stop(passy->scanner);

--- a/scenes/passy_scene_read.c
+++ b/scenes/passy_scene_read.c
@@ -109,9 +109,8 @@ bool passy_scene_read_on_event(void* context, SceneManagerEvent event) {
             }
         }
     } else if(event.type == SceneManagerEventTypeBack) {
-        scene_manager_search_and_switch_to_previous_scene(
+        consumed = scene_manager_search_and_switch_to_previous_scene(
             passy->scene_manager, PassySceneMainMenu);
-        consumed = true;
     }
 
     return consumed;

--- a/scenes/passy_scene_read.c
+++ b/scenes/passy_scene_read.c
@@ -38,7 +38,7 @@ void passy_scene_read_on_enter(void* context) {
 
     // Setup view
     Popup* popup = passy->popup;
-    popup_set_header(popup, "Reading", 68, 30, AlignLeft, AlignTop);
+    popup_set_header(popup, "Detecting...", 68, 30, AlignLeft, AlignTop);
     popup_set_icon(popup, 0, 3, &I_RFIDDolphinReceive_97x61);
     passy->scanner = nfc_scanner_alloc(passy->nfc);
     nfc_scanner_start(

--- a/scenes/passy_scene_read.c
+++ b/scenes/passy_scene_read.c
@@ -34,6 +34,8 @@ void passy_scene_read_on_enter(void* context) {
     Passy* passy = context;
     dolphin_deed(DolphinDeedNfcRead);
 
+    passy->poller = NULL;
+
     // Setup view
     Popup* popup = passy->popup;
     popup_set_header(popup, "Reading", 68, 30, AlignLeft, AlignTop);


### PR DESCRIPTION
This PR improves stability on going **back** while reading.

`passy->poller` is undefined when entering `passy_scene_read_on_enter` the first time. It is however checked and, if `!NULL` used in `passy_scene_read_on_exit`. This PR sets it to `NULL` initially.

This PR makes a disctiction between **detecting** and **reading**. While no NFC device is detected, the Flipper is in detecting mode. The label shown to the user is changed to reflect this.

The result of `scene_manager_search_and_switch_to_previous_scene` was not used and `true` was always returned. This PR changes the return value to depend on this call.

Most importantly, `passy_reader_free` is called after `nfc_poller_stop`. The NFC poller might, while its still running, call the `passy_reader_poller_callback`. This causes stability issues because data might still be coming in from the NFC poller, which was send to the already freed and therefore undefined `passy_reader`.

These changes partly solve #44; issues going back while reading
- small DG1 (MRZ) now tests successfully
- large DG2 (Face) no longer causes `furi_check failed`, but still hangs on reading